### PR TITLE
fixes #88

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -6,8 +6,6 @@
   children:
     - name: Bus, Trains &amp; Alerts
       path: http://www.transitchicago.com/developers/
-    - name: ClearPath API
-      path: http://api1.chicagopolice.org/clearpath/
     - name: DIVVY API
       path: https://www.divvybikes.com/system-data
     - name: GTFS
@@ -15,9 +13,9 @@
     - name: Health Atlas API
       path: https://api.chicagohealthatlas.org/api-docs/index.html
     - name: Lead Safe
-      path: docs/lead-safe
+      path: http://dev.cityofchicago.org/docs/lead-safe/
     - name: Open 311
-      path: docs/open311
+      path: http://dev.cityofchicago.org/docs/open311
     - name: OpenGrid Dev Docs
       path: http://opengrid.readthedocs.io
     - name: Plenario


### PR DESCRIPTION
Note this also fixes the links in RESOURCES that went to the ClearPath API (https://github.com/Chicago/dev.cityofchicago.org/pull/91).  There was no associated issue for this pull request. 

This adds absolute paths for the 311 and lead safe docs.

@nicklucius @jdkunesh @levyj 

Could one of you please test this. 
